### PR TITLE
Fix nanoid security advisory

### DIFF
--- a/azure-friday.core/package-lock.json
+++ b/azure-friday.core/package-lock.json
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- update the transitive `nanoid` lockfile entry from 3.3.16 to 3.3.18
- clear the remaining npm audit advisory after the PostCSS update

## Validation
- `npm ci --ignore-scripts`
- `npm audit --package-lock-only` reports 0 vulnerabilities