### PR TITLE
Run build and tests on pull requests

### DIFF
--- a/.github/workflows/its-azure-friday.yml
+++ b/.github/workflows/its-azure-friday.yml
@@ -3,12 +3,16 @@ on:
   push:
     branches:
     - master
+  pull_request:
+    branches:
+    - master
 env:
   AZURE_WEBAPP_NAME: its-azure-friday
   AZURE_WEBAPP_PACKAGE_PATH: azure-friday.core/publish
   AZURE_WEBAPP_PUBLISH_PROFILE: ${{secrets.itsazurefriday_1f35}}
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 10.0.x
+  TEST_PROJECT: azure-friday.tests/azure-friday.tests.csproj
   WORKING_DIRECTORY: azure-friday.core
 jobs:
   build-and-deploy:
@@ -30,20 +34,23 @@ jobs:
       run: npx tailwindcss -i wwwroot/css/input.css -o wwwroot/css/tailwind.css --minify
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: Restore
-      run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
+      run: dotnet restore "${{ env.TEST_PROJECT }}"
     - name: Build
-      run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
+      run: dotnet build "${{ env.TEST_PROJECT }}" --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Test
-      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
+      run: dotnet test "${{ env.TEST_PROJECT }}" --configuration ${{ env.CONFIGURATION }} --no-build
     - name: Publish
+      if: github.event_name == 'push'
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
     - name: Deploy to Azure WebApp
+      if: github.event_name == 'push'
       uses: azure/webapps-deploy@v2
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
     - name: Publish Artifacts
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v4
       with:
         name: webapp

--- a/.github/workflows/its-azure-friday.yml
+++ b/.github/workflows/its-azure-friday.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
     - name: Setup Node.js

--- a/azure-friday.tests/UnitTest1.cs
+++ b/azure-friday.tests/UnitTest1.cs
@@ -54,7 +54,6 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
     {
-        builder.UseSetting("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=00000000-0000-0000-0000-000000000000");
         builder.ConfigureServices(services =>
         {
             // Remove real IAzureFridayDB registration


### PR DESCRIPTION
## Summary
- run CI for pull requests targeting `master`
- restore, build, and test the actual `azure-friday.tests` project
- keep publish, Azure deployment, and artifact upload limited to pushes to `master`

## Validation
- npm install and Tailwind build succeeded
- .NET Release build succeeded
- all 23 tests passed
- .NET publish succeeded
- npm audit reports 0 vulnerabilities